### PR TITLE
Refresh dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 slog = "2"
-lazy_static = "0.2.1"
+lazy_static = "1.2"
 crossbeam = "0.2.9"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "lib.rs"
 [dependencies]
 slog = "2"
 lazy_static = "1.2"
-crossbeam = "0.2.9"
+crossbeam = "0.6"
 
 [dev-dependencies]
 slog-term = "~2.0.0-4"

--- a/lib.rs
+++ b/lib.rs
@@ -53,7 +53,7 @@
 
 #![warn(missing_docs)]
 
-#[macro_use(o, kv)]
+#[macro_use(o)]
 extern crate slog;
 #[macro_use]
 extern crate lazy_static;

--- a/lib.rs
+++ b/lib.rs
@@ -63,7 +63,7 @@ use slog::{Logger, Record, OwnedKVList};
 
 use std::sync::Arc;
 use std::cell::RefCell;
-use crossbeam::sync::ArcCell;
+use crossbeam::atomic::ArcCell;
 
 use std::result;
 


### PR DESCRIPTION
`slog-scope` wasn't updated for about a year now and its dependencies have become outdated. This PR updates them to the current versions (to reduce the number of oldish crates pulled in while using `slog-scope`)