### PR TITLE
Fix dependency versioning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 path = "lib.rs"
 
 [dependencies]
-slog = "2"
+slog = "2.4"
 lazy_static = "1.2"
 crossbeam = "0.6"
 


### PR DESCRIPTION
The recent changes to slog-scope v4.1.0 require 2018 edition-style macros support, which was added in slog 2.4.  This can cause compile errors on projcts pinned to older versions of slog.