### PR TITLE
Explicitly import slog macros to make usage more ergonomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.1.2 - unreleased
+
+* Call `slog` macros via `$crate::` prefix to prevent the users of this crate from having to manually import `slog_trace`, `slog_debug`, etc.
 
 ## 4.1.1 - 2018-12-20
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-scope"
-version = "4.1.1"
+version = "4.1.2"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "Logging scopes for slog-rs"
 keywords = ["slog", "logging", "slog", "log"]

--- a/lib.rs
+++ b/lib.rs
@@ -67,35 +67,37 @@ use arc_swap::ArcSwap;
 
 use std::result;
 
+pub use slog::{slog_crit, slog_debug, slog_error, slog_info, slog_trace, slog_warn};
+
 /// Log a critical level message using current scope logger
 #[macro_export]
 macro_rules! crit( ($($args:tt)+) => {
-    $crate::with_logger(|logger| slog_crit![logger, $($args)+])
+    $crate::with_logger(|logger| $crate::slog_crit![logger, $($args)+])
 };);
 /// Log a error level message using current scope logger
 #[macro_export]
 macro_rules! error( ($($args:tt)+) => {
-    $crate::with_logger(|logger| slog_error![logger, $($args)+])
+    $crate::with_logger(|logger| $crate::slog_error![logger, $($args)+])
 };);
 /// Log a warning level message using current scope logger
 #[macro_export]
 macro_rules! warn( ($($args:tt)+) => {
-    $crate::with_logger(|logger| slog_warn![logger, $($args)+])
+    $crate::with_logger(|logger| $crate::slog_warn![logger, $($args)+])
 };);
 /// Log a info level message using current scope logger
 #[macro_export]
 macro_rules! info( ($($args:tt)+) => {
-    $crate::with_logger(|logger| slog_info![logger, $($args)+])
+    $crate::with_logger(|logger| $crate::slog_info![logger, $($args)+])
 };);
 /// Log a debug level message using current scope logger
 #[macro_export]
 macro_rules! debug( ($($args:tt)+) => {
-    $crate::with_logger(|logger| slog_debug![logger, $($args)+])
+    $crate::with_logger(|logger| $crate::slog_debug![logger, $($args)+])
 };);
 /// Log a trace level message using current scope logger
 #[macro_export]
 macro_rules! trace( ($($args:tt)+) => {
-    $crate::with_logger(|logger| slog_trace![logger, $($args)+])
+    $crate::with_logger(|logger| $crate::slog_trace![logger, $($args)+])
 };);
 
 thread_local! {


### PR DESCRIPTION
Hi!

Without this PR, whoever uses the `slog-scope` crate needs to also import the various `slog_*` macros into their namespace. The change proposed here removes the need from to do that, allowing for more ergonomic use.

My use-case for this is a crate that deals with logging in a (private) app I am working on. I want to be able to do something like `use my_log::trace`. Inside `my_log`, I have `pub use slog_scope::{crit, debug, error, info, trace, warn}`. However, if I only do `use my_log::trace` without `use slog::slog_trace`, the build fails. Being able to use stuff from `slog` means that every crate I have that depends on `my_log` would also need an explicit dependency on `slog`. I hope this explains the need for this PR.

Thanks!