### PR TITLE
Add getter for GlobalLoggerGuard

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -135,7 +135,7 @@ impl slog::Drain for NoGlobalLoggerSet {
 /// This will `drop` any existing global logger.
 #[must_use]
 pub struct GlobalLoggerGuard {
-    canceled : bool,
+   pub canceled : bool,
 }
 
 impl GlobalLoggerGuard {

--- a/lib.rs
+++ b/lib.rs
@@ -140,7 +140,7 @@ pub struct GlobalLoggerGuard {
 
 impl GlobalLoggerGuard {
     fn get_canceled(&self) -> bool {
-        return &self.canceled 
+        return &self.canceled; 
     }
 
     fn new() -> Self {

--- a/lib.rs
+++ b/lib.rs
@@ -135,10 +135,13 @@ impl slog::Drain for NoGlobalLoggerSet {
 /// This will `drop` any existing global logger.
 #[must_use]
 pub struct GlobalLoggerGuard {
-   pub canceled : bool,
+   canceled : bool,
 }
 
 impl GlobalLoggerGuard {
+    fn get_canceled(&self) -> bool {
+        return &self.canceled 
+    }
 
     fn new() -> Self {
         GlobalLoggerGuard {

--- a/lib.rs
+++ b/lib.rs
@@ -139,8 +139,9 @@ pub struct GlobalLoggerGuard {
 }
 
 impl GlobalLoggerGuard {
-    fn get_canceled(&self) -> bool {
-        return &self.canceled; 
+    /// Getter for canceled to check status 
+    pub fn get_canceled(self) -> bool {
+        return self.canceled;
     }
 
     fn new() -> Self {


### PR DESCRIPTION
Set the property public so that those who set Logger global can figure out whether the logger is set already with accessing its GlobalLoggerGuard's property after return from `set_global_logger`.