### PR TITLE
Update arc-swap to v1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "lib.rs"
 [dependencies]
 slog = "2.4"
 lazy_static = "1.2"
-arc-swap = "0.4"
+arc-swap = "1.1"
 
 [dev-dependencies]
 slog-term = "2"


### PR DESCRIPTION
Update arc-swap to satisfy the dependency tree.

See also https://github.com/slog-rs/atomic/pull/7