### PR TITLE
Fix docs on GlobalLoggerGuard to reflect Drop behavior

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -131,7 +131,8 @@ impl slog::Drain for NoGlobalLoggerSet {
 
 /// Guard resetting global logger
 ///
-/// On drop it will reset global logger to `slog::Discard`.
+/// On drop it will reset global logger to an `slog::Drain` that panics upon receiving a log record,
+/// so use outside of main is discouraged.
 /// This will `drop` any existing global logger.
 #[must_use]
 pub struct GlobalLoggerGuard {


### PR DESCRIPTION
GlobalLoggerGuard is installing NoGlobalLoggerSet as a drain, rather than
slog::Discard.  The distinction seems notable, due to the panic behavior of
NoGlobalLoggerSet.  This updates the docs to reflect the current behavior.