### PR TITLE
slog 2.8 deprecation warnings fix

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -67,7 +67,10 @@ use arc_swap::ArcSwap;
 
 use std::result;
 
-pub use slog::{slog_crit, slog_debug, slog_error, slog_info, slog_trace, slog_warn};
+pub use slog::{
+    crit as slog_crit, debug as slog_debug, error as slog_error, info as slog_info,
+    trace as slog_trace, warn as slog_warn,
+};
 
 /// Log a critical level message using current scope logger
 #[macro_export]

--- a/lib.rs
+++ b/lib.rs
@@ -248,6 +248,6 @@ where F : FnOnce(&Logger) -> R {
 pub fn scope<SF, R>(logger: &slog::Logger, f: SF) -> R
     where SF: FnOnce() -> R
 {
-    let _guard = ScopeGuard::new(&logger);
+    let _guard = ScopeGuard::new(logger);
     f()
 }


### PR DESCRIPTION
Hello, offering the upstream a tiny fix to get around some fresh deprecation warnings:
```
warning: use of deprecated macro `slog::slog_crit`: Use fully qualified macro slog::crit!(...) instead
  --> lib.rs:70:16
   |
70 | pub use slog::{slog_crit, slog_debug, slog_error, slog_info, slog_trace, slog_warn};
   |                ^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: use of deprecated macro `slog::slog_debug`: Use fully qualified macro slog::warn!(...) instead
  --> lib.rs:70:27
   |
70 | pub use slog::{slog_crit, slog_debug, slog_error, slog_info, slog_trace, slog_warn};
   |                           ^^^^^^^^^^

warning: use of deprecated macro `slog::slog_error`: Use fully qualified macro slog::crit!(...) instead
  --> lib.rs:70:39
   |
70 | pub use slog::{slog_crit, slog_debug, slog_error, slog_info, slog_trace, slog_warn};
   |                                       ^^^^^^^^^^

warning: use of deprecated macro `slog::slog_info`: Use fully qualified macro slog::info!(...) instead
  --> lib.rs:70:51
   |
70 | pub use slog::{slog_crit, slog_debug, slog_error, slog_info, slog_trace, slog_warn};
   |                                                   ^^^^^^^^^

warning: use of deprecated macro `slog::slog_trace`: Use fully qualified macro slog::trace!(...) instead
  --> lib.rs:70:62
   |
70 | pub use slog::{slog_crit, slog_debug, slog_error, slog_info, slog_trace, slog_warn};
   |                                                              ^^^^^^^^^^

warning: use of deprecated macro `slog::slog_warn`: Use fully qualified macro slog::warn!(...) instead
  --> lib.rs:70:74
   |
70 | pub use slog::{slog_crit, slog_debug, slog_error, slog_info, slog_trace, slog_warn};
   |                                                                          ^^^^^^^^^

```
+ one even tinier clippy warning fix :)